### PR TITLE
[TEST] Trim in config

### DIFF
--- a/__test__/config.test.js
+++ b/__test__/config.test.js
@@ -5,9 +5,31 @@ describe('Configuration Module', () => {
     config.reset();
   });
 
-  describe('Finder registraition', () => {
+  describe('Trim', () => {
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    test('it trims markup to single-spaced string', () => {
+      const markup = `
+        <button id="expected">
+          <h3>Button Title</h3>
+          <p>Description</p>
+        </button>
+      `;
+      document.body.innerHTML = markup;
+      expect(config.trim(document.body.innerHTML))
+        .toEqual('<button id="expected"> <h3>Button Title</h3> <p>Description</p> </button>');
+    });
+
+    test('check dom', () => {
+      expect(document.body.innerHTML).toEqual('');
+    });
+  });
+
+  describe('Finder registration', () => {
     describe('Registering a finder', () => {
-      it('it adds it to registerdFinderArray', () => {
+      it('adds it to registerdFinderArray', () => {
         config.registerFinder({
           key: 'custom-finder',
         });


### PR DESCRIPTION
Porting over the test for `trim` currently sitting in [ember-semantic-test-helpers](https://github.com/tradegecko/ember-semantic-test-helpers/blob/56dba8cb715d41a115d0a91cd65e9bcb95620604/tests/integration/semantic-finders/trimming-test.js#L10..L20)