### PR TITLE
[TEST] Find by label

### DIFF
--- a/__test__/finders/__snapshots__/find-by-label.test.js.snap
+++ b/__test__/finders/__snapshots__/find-by-label.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Find by label Label exists without "for" attribute throws error 1`] = `"Label was found for Hello! but it did not have a for attribute"`;

--- a/__test__/finders/find-by-label.test.js
+++ b/__test__/finders/find-by-label.test.js
@@ -1,0 +1,88 @@
+import findByLabel from '../../src/finders/find-by-label';
+import { textQuery } from '../../src/definitions/selectors';
+
+describe('Find by label', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('Label exists', () => {
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    describe('with "for" attribute targetting input', () => {
+      beforeEach(() => {
+        const markup = `
+          <label for="proper">Hello!</label>
+          <label for="notproper">Another Hello!</label>
+          <div id="proper">
+            <input name="proper" value="happy" />
+          </div>
+          <input name="notproper" value="sad"/>
+        `;
+        document.body.innerHTML = markup;
+      });
+
+      it('finds the right input', () => {
+        const expectedInput = document.querySelector('input[value="happy"]');
+        const foundInput = findByLabel.run(textQuery, 'Hello!');
+        expect(foundInput.length).toEqual(1);
+        expect(foundInput[0]).toEqual(expectedInput);
+      });
+    });
+
+    describe('with "for" attribute targetting div', () => {
+      beforeEach(() => {
+        const markup = `
+          <label for="control">Label of control</label>
+          <div class="day-slider">
+            <div id="control" class="day-slider-handle" role="slider"
+               aria-valuemin="1"
+               aria-valuemax="7"
+               aria-valuenow="2"
+               aria-valuetext="Monday">
+           </div>
+          </div>
+        `;
+        document.body.innerHTML = markup;
+      });
+
+      it('finds the right input', () => {
+        const expectedInput = document.querySelector('#control');
+        const foundInput = findByLabel.run(textQuery, 'Label of control');
+        expect(foundInput.length).toEqual(1);
+        expect(foundInput[0]).toEqual(expectedInput);
+      });
+    });
+
+    describe('without "for" attribute', () => {
+      beforeEach(() => {
+        const markup = `
+          <label>Hello!</label>
+        `;
+        document.body.innerHTML = markup;
+      });
+
+      it('throws error', async () => {
+        expect(() => {
+          findByLabel.run(textQuery, 'Hello!');
+        }).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+
+  describe('Label does not exist', () => {
+    beforeEach(() => {
+      const markup = `
+        <div for="trickery">Hello!</div>
+        <input name="trickery"/>
+      `;
+      document.body.innerHTML = markup;
+    });
+
+    it('returns null', () => {
+      expect(findByLabel.run(textQuery, 'Hello!')).toEqual(null);
+    });
+  });
+});

--- a/src/finders/find-by-aria/compute-aria.js
+++ b/src/finders/find-by-aria/compute-aria.js
@@ -32,6 +32,11 @@ const computeTextAlternativeForElement = (element, label = '') => {
     label = element.attributes.title.value;
   }
 
+  // fallback textContent for labels
+  if (!label && element.textContent) {
+    label = element.textContent;
+  }
+
   return label;
 };
 


### PR DESCRIPTION
Added a fallback to [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) of `label` in the magic function.

Ported over some tests from [`ember-semantic-test-helpers`](https://github.com/tradegecko/ember-semantic-test-helpers/blob/1172419c1edc0b1e94b87b5828fb609084da037c/tests/integration/components/dom/find-by-label-test.js)
though I did change the first markup of that existing test. Think this might be more comprehensive.
