### PR TITLE
[ENHANCEMENT] Find Control allows finding buttons

### DIFF
--- a/src/find-functions.js
+++ b/src/find-functions.js
@@ -46,6 +46,9 @@ const _findControl = function (method, labelText, type = 'form') {
 };
 
 export function findControl(labelText, type) {
+  if (type === 'button') {
+    return this.findButton(labelText);
+  }
   return _findControl(findObject, labelText, type);
 }
 


### PR DESCRIPTION
Fixes https://github.com/tradegecko/semantic-dom-selectors/issues/4
Allows FindControl to also find buttons without having to call findButton('labelText')