### PR TITLE
test(findControl): Port find controll test from ember repo

### DIFF
--- a/__test__/find-control.test.js
+++ b/__test__/find-control.test.js
@@ -1,0 +1,90 @@
+import { findControl } from '../src/find-functions';
+import configure from '../src/configure';
+import config from '../src/config';
+
+describe('Find Control', () => {
+  beforeEach(() => {
+    configure({ preset: 'default', rules: { 'invalid-label-for': 0 } });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    config.reset();
+  });
+
+  test('default type finds input', () => {
+    /*
+      currently throwing error Control Label of control found through invalid label for relationship
+      when it is valid, the bug is in the way notifier works
+    */
+    configure({ preset: 'default', rules: { 'invalid-label-for': 'warn' } });
+    document.body.innerHTML = `
+      <label for="control">this is my input</label>
+      <input id="control" type="text" name="text" />
+    `;
+    const foundInput = findControl('this is my input');
+    expect(foundInput).toEqual(document.querySelector('input[id="control"]'));
+  });
+
+  test('default type finds text-area', () => {
+    document.body.innerHTML = `
+      <label for='control'>Label of control</label>
+      <textarea id="control" />
+    `;
+    try {
+      findControl('Label of control');
+    } catch (e) {
+      expect(e.message).toEqual('Control Label of control found through invalid label for relationship');
+    }
+  });
+
+  test('finds element even though role is wrong', () => {
+    document.body.innerHTML = `
+      <label for="control">Label of control</label>
+      <div class="day-slider">
+        <div id="control" class="day-slider-handle" role="slider"
+           aria-valuemin="1"
+           aria-valuemax="7"
+           aria-valuenow="2"
+           aria-valuetext="Monday">
+       </div>
+      </div>
+    `;
+    try {
+      findControl('Label of control');
+    } catch (e) {
+      expect(e.message).toEqual('Control Label of control found through invalid label for relationship');
+    }
+  });
+
+  test('finds contenteditable="true"', () => {
+    document.body.innerHTML = `
+      <p  id="control" contenteditable="true"> i am a strange text box</p>
+    `;
+    const foundInput = findControl('i am a strange text box');
+    expect(foundInput).toEqual(document.querySelector('p[id="control"]'));
+  });
+
+  test('finds role="textbox"', () => {
+    document.body.innerHTML = `
+      <p id="control" role="textbox"> i am a strange text box</p>
+    `;
+    const foundInput = findControl('i am a strange text box');
+    expect(foundInput).toEqual(document.querySelector('p[id="control"]'));
+  });
+
+  test('finds role="slider"', async () => {
+    document.body.innerHTML = `
+      <div class="day-slider">
+        <div id="control" class="day-slider-handle" role="slider" aria-label="Label of control"
+           aria-valuemin="1"
+           aria-valuemax="7"
+           aria-valuenow="2"
+           aria-valuetext="Monday">
+       </div>
+      </div>
+    `;
+    const foundInput = findControl('Label of control');
+    expect(foundInput).toEqual(document.querySelector('div[id="control"]'));
+  });
+});

--- a/src/find-functions.js
+++ b/src/find-functions.js
@@ -21,7 +21,7 @@ export function findObjects(selector, labelText, type = 'object') {
     const strategy = finder.run;
 
     const objects = strategy(selector, labelText);
-    if (objects || objects.length > 0) {
+    if (objects && objects.length > 0) {
       if (key !== 'not-aria-compliant') {
         notify(key, type, labelText, finder.errorText);
       }


### PR DESCRIPTION
Took over the following https://github.com/tradegecko/semantic-dom-selectors/pull/20, the goal was to remove tests from the ember repo and bring them here.