### PR TITLE
[FEATURE] find by selector

### DIFF
--- a/__test__/finders/find-by-selector.test.js
+++ b/__test__/finders/find-by-selector.test.js
@@ -1,30 +1,55 @@
 import findBySelector from '../../src/finders/find-by-selector';
 
 describe('Find by selector', () => {
-  beforeEach(() => {
-    const markup = `
-      <div class="parent">
-        <button id="ni" class="child" />
-      </div>
-    `;
-    document.body.innerHTML = markup;
+  describe('when dom is semantic', () => {
+    beforeEach(() => {
+      const markup = `
+        <div class="parent">
+          <button id="ni" class="child" />
+        </div>
+      `;
+      document.body.innerHTML = markup;
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('finds the child button', () => {
+      const expectedButton = document.querySelector('#ni');
+      const foundButton = findBySelector.run('button', '.child');
+      expect(foundButton.length).toEqual(1);
+      expect(foundButton[0]).toEqual(expectedButton);
+    });
+
+    it('finds the child button via parent', () => {
+      const expectedButton = document.querySelector('#ni');
+      const foundButton = findBySelector.run('.parent', '> .child');
+      expect(foundButton.length).toEqual(1);
+      expect(foundButton[0]).toEqual(expectedButton);
+    });
   });
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-  });
+  describe('when dom is not semantic', () => {
+    beforeEach(() => {
+      const markup = `
+        <div class="parent">
+          <span id="ni" class="child" />
+        </div>
+      `;
+      document.body.innerHTML = markup;
+    });
 
-  it('finds the child button', () => {
-    const expectedButton = document.querySelector('#ni');
-    const foundButton = findBySelector.run('button', '.child');
-    expect(foundButton.length).toEqual(1);
-    expect(foundButton[0]).toEqual(expectedButton);
-  });
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
 
-  it('finds the child button via parent', () => {
-    const expectedButton = document.querySelector('#ni');
-    const foundButton = findBySelector.run('.parent', '> .child');
-    expect(foundButton.length).toEqual(1);
-    expect(foundButton[0]).toEqual(expectedButton);
+    it('finds the child button', () => {
+      try {
+        findBySelector.run('button', '.child');
+      } catch (e) {
+        expect(e.message).toEqual('Element found with invalid role');
+      }
+    });
   });
 });

--- a/__test__/finders/find-by-selector.test.js
+++ b/__test__/finders/find-by-selector.test.js
@@ -1,0 +1,30 @@
+import findBySelector from '../../src/finders/find-by-selector';
+
+describe('Find by selector', () => {
+  beforeEach(() => {
+    const markup = `
+      <div class="parent">
+        <button id="ni" class="child" />
+      </div>
+    `;
+    document.body.innerHTML = markup;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('finds the child button', () => {
+    const expectedButton = document.querySelector('#ni');
+    const foundButton = findBySelector.run('button', '.child');
+    expect(foundButton.length).toEqual(1);
+    expect(foundButton[0]).toEqual(expectedButton);
+  });
+
+  it('finds the child button via parent', () => {
+    const expectedButton = document.querySelector('#ni');
+    const foundButton = findBySelector.run('.parent', '> .child');
+    expect(foundButton.length).toEqual(1);
+    expect(foundButton[0]).toEqual(expectedButton);
+  });
+});

--- a/src/finders/find-by-selector.js
+++ b/src/finders/find-by-selector.js
@@ -1,0 +1,29 @@
+import findAll from './helpers/findAll';
+import notify from '../notify';
+
+function findBySelector(selector, text) {
+  const elements = selector.split(',');
+  let objects;
+
+  const childElementSelector = elements.map(element => `${element} ${text}`).join(',');
+  objects = findAll(childElementSelector);
+
+  if (!objects || objects.length === 0) {
+    objects = findAll(text);
+
+    if (objects) {
+      objects.forEach((object) => {
+        if (!object.matches(selector)) {
+          notify('query-selector-invalid-role', 'object', text, () => 'Element found with invalid role');
+        }
+      });
+    }
+  }
+
+  return objects;
+}
+
+export default {
+  run: findBySelector,
+  key: 'query-selector',
+};


### PR DESCRIPTION
adding `find-by-selector` to perform search on query selector instead of label text.

This will allow query-selector to flow through:
`.my-class` -> `findObject` -> `finder.run` -> `find-by-selector`