### PR TITLE
feat(within-element): Create within element helper

### DIFF
--- a/__test__/helpers/__snapshots__/within-element.test.js.snap
+++ b/__test__/helpers/__snapshots__/within-element.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`within-element if no within throws error 1`] = `"Control this is my input found through invalid label for relationship"`;

--- a/__test__/helpers/within-element.test.js
+++ b/__test__/helpers/within-element.test.js
@@ -1,0 +1,41 @@
+import { findControl } from '../../src/find-functions';
+import withinElement from '../../src/helpers/within-element';
+import configure from '../../src/configure';
+
+describe('within-element', () => {
+  beforeEach(() => {
+    /*
+      TODO:invalid-for-relationship-bug
+      currently throwing error Control Label of control found through invalid label for relationship
+      when it is valid, the bug is in the way notifier works
+    */
+    configure({ preset: 'default', rules: { 'invalid-label-for': 0 } });
+    document.body.innerHTML = `
+      <div id="section-one">
+        <label for="control">this is my input</label>
+        <input id="control" type="text" name="text" />
+      </div>
+      <div id="section-two">
+        <label for="control">this is my input</label>
+        <input id="control" type="text" name="text" />
+      </div>
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('if mutliple elements scopes to within section', () => {
+    withinElement(document.querySelector('#section-one'), () => {
+      const foundInput = findControl('this is my input');
+      expect(foundInput).toEqual(document.querySelector('input[id="control"]'));
+    });
+  });
+
+  test('if no within throws error', () => {
+    expect(() => {
+      findControl('this is my input');
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/helpers/within-element.js
+++ b/src/helpers/within-element.js
@@ -1,0 +1,8 @@
+import config from '../config';
+
+export default async function within(root, func) {
+  const oldRoot = config.rootElement;
+  config.rootElement = root;
+  await func();
+  config.rootElement = oldRoot;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import * as types from './definitions/types';
 import findByAria from './finders/find-by-aria/rule';
 import findByLabel from './finders/find-by-label';
 import findByName from './finders/find-by-name';
+import withinElement from './helpers/within-element';
 
 config.defaultFinders = [findByAria, findByLabel, findByName];
 
@@ -35,4 +36,5 @@ export default {
   selectQuery,
   formControlQuery,
   types,
+  withinElement,
 };


### PR DESCRIPTION
The longer-term vision is to create a helper `withinSection` that will use the helper and find a section with a specific label.

But before doing that I need to be able to find sections